### PR TITLE
Automatic start services when VM boots

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The virtual machine will be running the following services:
 7. Execute ```vagrant ssh``` to login to the VM.
 
 
-# Map Reduce - Tez 
+# Map Reduce - Tez
 
 By default map reduce jobs will be executed via Tez to change this to standard MR, change the following parameter in $HADOOP_CONF/mapred-site.xml from: -
 
@@ -82,14 +82,14 @@ Notebook server can then be accessed via `http://10.211.55.101:8080`.
 
 # Mysql
 
-mysql database connection 
+mysql database connection
 
-* `root@10.211.55.101:3306` (for root DBA access - password is 'root') 
+* `root@10.211.55.101:3306` (for root DBA access - password is 'root')
 * `hive@10.211.55.101:3306` (for hive metastore user - password is 'hive')
 
 # Shared Folder
 
-Vagrant automatically mounts the folder containing the Vagrant file from the host machine into 
+Vagrant automatically mounts the folder containing the Vagrant file from the host machine into
 the guest machine as `/vagrant` inside the guest.
 
 
@@ -113,8 +113,7 @@ or
 vagrant suspend
 ```
 
-Issue a `vagrant up` command again to restart the VM from where you left off. See, *starting services* below to restart the
-hdfs/yarn/hive and spark daemons.
+Issue a `vagrant up` command again to restart the VM from where you left off.
 
 To completely **wipe** the VM so that `vagrant up` command gives you a fresh machine: -
 
@@ -123,21 +122,6 @@ vagrant destroy
 ```
 
 Then issue `vagrant up` command as usual.
-
-# Starting services in the event of a system restart
-
-If you restart your VM then the Hadoop/Spark/Hive services won't be
-up, to bring them up manually use:
-
-```
-$ vagrant ssh
-$ sudo -sE
-$ systemctl start mysql.service
-$ /vagrant/scripts/start-hadoop.sh		# Starts the namenode/datanode plus yarn.
-$ /vagrant/scripts/start-hive.sh		# Start hiveserver2 plus metastore service.
-$ /vagrant/scripts/start-spark.sh		# Start Spark history server.
-
-```
 
 # To shutdown services cleanly
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,32 +1,33 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-Vagrant.require_version ">= 1.4.3"
-VAGRANTFILE_API_VERSION = "2"
+Vagrant.require_version '>= 1.4.3'
+VAGRANTFILE_API_VERSION = '2'.freeze
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     i = 1
     config.vm.network :forwarded_port, guest: 8080, host: 8080
     config.vm.define "node#{i}" do |node|
-        node.vm.box = "ubuntu/xenial64"
-	config.vm.define :node1 do |t|
+        node.vm.box = 'ubuntu/xenial64'
+        config.vm.define :node1 do |t|
         end
-        node.vm.provider "virtualbox" do |v|
-          v.name = "node#{i}"
-          v.customize ["modifyvm", :id, "--memory", "8192"]
+        node.vm.provider 'virtualbox' do |v|
+            v.name = "node#{i}"
+            v.customize ['modifyvm', :id, '--memory', '8192']
         end
-        node.vm.network :private_network, ip: "10.211.55.101"
-        node.vm.hostname = "node1"
-        node.vm.provision "shell", path: "scripts/setup-ubuntu.sh"
-        node.vm.provision "shell", path: "scripts/setup-java.sh"
- 	node.vm.provision "shell", path: "scripts/setup-mysql.sh"
-        node.vm.provision "shell", path: "scripts/setup-hadoop.sh"
-        node.vm.provision "shell", path: "scripts/setup-hive.sh"
-        node.vm.provision "shell", path: "scripts/setup-spark.sh"
-        node.vm.provision "shell", path: "scripts/setup-tez.sh"
-        node.vm.provision "shell", path: "scripts/setup-pig.sh"
-        node.vm.provision "shell", path: "scripts/setup-flume.sh"
-        node.vm.provision "shell", path: "scripts/setup-sqoop.sh"
-        node.vm.provision "shell", path: "scripts/setup-zeppelin.sh"
-        node.vm.provision "shell", path: "scripts/finalize-ubuntu.sh"
+        node.vm.network :private_network, ip: '10.211.55.101'
+        node.vm.hostname = 'node1'
+        node.vm.provision :shell, path: 'scripts/setup-ubuntu.sh'
+        node.vm.provision :shell, path: 'scripts/setup-java.sh'
+        node.vm.provision :shell, path: 'scripts/setup-mysql.sh'
+        node.vm.provision :shell, path: 'scripts/setup-hadoop.sh'
+        node.vm.provision :shell, path: 'scripts/setup-hive.sh'
+        node.vm.provision :shell, path: 'scripts/setup-spark.sh'
+        node.vm.provision :shell, path: 'scripts/setup-tez.sh'
+        node.vm.provision :shell, path: 'scripts/setup-pig.sh'
+        node.vm.provision :shell, path: 'scripts/setup-flume.sh'
+        node.vm.provision :shell, path: 'scripts/setup-sqoop.sh'
+        node.vm.provision :shell, path: 'scripts/setup-zeppelin.sh'
+        node.vm.provision :shell, path: 'scripts/finalize-ubuntu.sh'
+        node.vm.provision :shell, path: 'scripts/bootstrap.sh', run: 'always'
     end
 end

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# If you restart your VM then the Hadoop/Spark/Hive services will be started by this script.
+# Due to the config "node.vm.provision :shell, path: "scripts/bootstrap.sh", run: 'always'" on Vagrantfile
+
+systemctl start mysql.service
+/vagrant/scripts/start-hadoop.sh	# Starts the namenode/datanode plus yarn.
+/vagrant/scripts/start-hive.sh		# Start hiveserver2 plus metastore service.
+/vagrant/scripts/start-spark.sh		# Start Spark history server.

--- a/scripts/start-hive.sh
+++ b/scripts/start-hive.sh
@@ -5,10 +5,15 @@ source "/vagrant/scripts/common.sh"
 function startHive {
     echo "starting Hive daemons"
     export HADOOP_HOME=${HADOOP_PREFIX}
-    nohup ${HIVE_PREFIX}/bin/hive --service metastore < /dev/null > /usr/local/hive/logs/hive_metastore_`date +"%Y%m%d%H%M%S"`.log 2>&1 </dev/null &
-    nohup ${HIVE_PREFIX}/bin/hive --service hiveserver2 < /dev/null > /usr/local/hive/logs/hive_server2_`date +"%Y%m%d%H%M%S"`.log 2>&1 </dev/null &
+    HIVE_LOGPATH=/usr/local/hive/logs
+    if [ -z $(pgrep -f HiveMetaStore) ]; then
+        nohup ${HIVE_PREFIX}/bin/hive --service metastore < /dev/null > ${HIVE_LOGPATH}/hive_metastore_`date +"%Y%m%d%H%M%S"`.log 2>&1 </dev/null &
+    fi
+    if [ -z $(pgrep -f HiveServer2) ]; then
+        nohup ${HIVE_PREFIX}/bin/hive --service hiveserver2 < /dev/null > ${HIVE_LOGPATH}/hive_server2_`date +"%Y%m%d%H%M%S"`.log 2>&1 </dev/null &
+    fi
     echo "listing all Java processes"
     jps
 }
 
-startHive     
+startHive


### PR DESCRIPTION
I've used the gem `rubocop` to beautify the Vagrantfile, according to ruby code style. And added the following scripts:

- scripts/bootstrap.sh file created, this script will start all necessary services whenever vagrant up is running;
- scripts/start-hive.sh improved, since it uses nohup, the service could be duplicated. It will first check if there's running processes, and will start *only if* it doesn't.

And files:
- Manually service start removed from README.md, it's no longer necessary, since it's automatic;
- Vagrantfile config: "node.vm.provision :shell, path: 'scripts/bootstrap.sh', run: 'always'" added. To always execute scripts/bootstrap.sh during VM boot. Whenever someone runs 'vagrant up'

It will reduce pain of restarting the VM (: