### PR TITLE
update zeppelin to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The virtual machine will be running the following services:
     * Sqoop 1.4.6
     * Pig 0.17.0
     * flume 1.7.0
-    * Zeppelin 0.7.2 (with Spark/scala, md, file and JDBC interpreters)
+    * Zeppelin 0.8.0 (with Spark/scala, md, file and JDBC interpreters)
 * Release `Spark-2.3.0` based on: -
     * Hadoop 2.7.6
     * Hive 2.3.3
@@ -50,7 +50,7 @@ The virtual machine will be running the following services:
     * Sqoop 1.4.6
     * Pig 0.17.0
     * flume 1.7.0
-    * Zeppelin 0.7.2 (with Spark/scala, md, file and JDBC interpreters)
+    * Zeppelin 0.8.0 (with Spark/scala, md, file and JDBC interpreters)
 4. In your terminal change your directory into the project directory (i.e. `cd vagrant-hadoop-spark-hive-<version>`).
 5. Run ```vagrant up``` to create the VM (**NOTE** *This will take a while the first time as many dependencies are downloaded - subsequent deployments will be quicker as dependancies are cached in the `resources` directory*).
 6. Execute ```vagrant ssh``` to login to the VM.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -81,7 +81,7 @@ FLUME_MIRROR_DOWNLOAD=http://www.mirrorservice.org/sites/ftp.apache.org/flume/${
 FLUME_RES_DIR=/vagrant/resources/flume
 
 # Zeppelin 
-ZEPPELIN_VERSION=0.7.2
+ZEPPELIN_VERSION=0.8.0
 ZEPPELIN_RELEASE=zeppelin-${ZEPPELIN_VERSION}-bin-netinst
 ZEPPELIN_ARCHIVE=${ZEPPELIN_RELEASE}.tgz
 ZEPPELIN_MIRROR_DOWNLOAD=http://www-eu.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${ZEPPELIN_ARCHIVE}


### PR DESCRIPTION
The zeppelin 0.7.2 can not be gotten by now and I wish update it to 0.8.0 accordingly.