### PR TITLE
update zeppelin to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Vagrant project to spin up a single virtual machine running:
 * Sqoop 1.4.6
 * Pig 0.17.0
 * flume 1.7.0
-* Zeppelin 0.7.2 (with Spark/scala, md, file and JDBC interpreters)
+* Zeppelin 0.8.0 (with Spark/scala, md, file and JDBC interpreters)
 
 The virtual machine will be running the following services:
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,7 +77,7 @@ FLUME_MIRROR_DOWNLOAD=http://www.mirrorservice.org/sites/ftp.apache.org/flume/${
 FLUME_RES_DIR=/vagrant/resources/flume
 
 # Zeppelin 
-ZEPPELIN_VERSION=0.7.3
+ZEPPELIN_VERSION=0.8.0
 ZEPPELIN_RELEASE=zeppelin-${ZEPPELIN_VERSION}-bin-netinst
 ZEPPELIN_ARCHIVE=${ZEPPELIN_RELEASE}.tgz
 ZEPPELIN_MIRROR_DOWNLOAD=http://www-eu.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${ZEPPELIN_ARCHIVE}


### PR DESCRIPTION
The zeppelin 0.7.x can not be gotten by now and I wish update it to 0.8.0 accordingly.